### PR TITLE
mScrollListener nullable check

### DIFF
--- a/Sample-of-Android-week-view/library/src/main/java/com/guojunustb/library/WeekDayView.java
+++ b/Sample-of-Android-week-view/library/src/main/java/com/guojunustb/library/WeekDayView.java
@@ -1408,7 +1408,9 @@ public class WeekDayView extends View {
             mSelectedDate = (Calendar) mToday.clone();
             mSelectedDate.add(Calendar.DATE, -leftDays);
             if (mSelectedDate.get(Calendar.DAY_OF_YEAR) != mLastSelectedDate.get(Calendar.DAY_OF_YEAR)) {
-                mScrollListener.onSelectedDaeChange(mSelectedDate);
+                if (mScrollListener != null) {
+                    mScrollListener.onSelectedDaeChange(mSelectedDate);   
+                }
             }
             mCurrentScrollDirection = Direction.NONE;
         }


### PR DESCRIPTION
mScrollListener can be nullable, there is a crash -
 java.lang.NullPointerException: Attempt to invoke interface method 'void com.guojunustb.library.WeekDayView$ScrollListener.onSelectedDaeChange(java.util.Calendar)' on a null object reference
        at com.guojunustb.library.WeekDayView.onTouchEvent(WeekDayView.java:1416)